### PR TITLE
Bug fixed: new instances of nodes are always of type KZNNode…

### DIFF
--- a/Pod/Classes/Node/KZNNode.m
+++ b/Pod/Classes/Node/KZNNode.m
@@ -27,7 +27,7 @@
     return [UINib nibWithNibName:NSStringFromClass(self.class) bundle:[NSBundle mainBundle]];
   }
 
-  if ([[NSBundle mainBundle] pathForResource:NSStringFromClass(self.class) ofType:@"nib"]) {
+  if ([[NSBundle bundleForClass:[KZNNode class]] pathForResource:NSStringFromClass(self.class) ofType:@"nib"]) {
     return [UINib nibWithNibName:NSStringFromClass(self.class) bundle:[NSBundle bundleForClass:self.class]];
   }
 


### PR DESCRIPTION
…because the pod was looking for resource files in mainBundle instead inside pod resources.

