### PR TITLE
Nodes compositions can be restored without remove current nodes on grid.

### DIFF
--- a/Example/KZNodes/KZPlaygroundExample.m
+++ b/Example/KZNodes/KZPlaygroundExample.m
@@ -263,6 +263,6 @@
   NSUserDefaults *currentDefaults = [NSUserDefaults standardUserDefaults];
   NSArray *savedArray = [currentDefaults objectForKey:@"nodesSavedArray"];
 
-  [_workspace restoreNodesCompositionFrom:savedArray];
+  [_workspace restoreNodesCompositionFrom:savedArray removeNodesFromGrid:YES];
 }
 @end

--- a/Pod/Classes/Workspace/KZNWorkspace.h
+++ b/Pod/Classes/Workspace/KZNWorkspace.h
@@ -25,5 +25,5 @@
 
 - (void)evaluate;
 - (NSArray*)arrayWithNodesComposition;
-- (void)restoreNodesCompositionFrom:(NSArray*)serializedObjects;
+- (void)restoreNodesCompositionFrom:(NSArray*)serializedObjects removeNodesFromGrid:(BOOL)removeNodes;
 @end


### PR DESCRIPTION
New parameter 'removeNodesFromGrid' for 'restoreNodesComposition' function allows select if remove or not current nodes before import stored composition.